### PR TITLE
Upgrade faraday dependency

### DIFF
--- a/cmis-ruby.gemspec
+++ b/cmis-ruby.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency        'faraday',            '~> 0.9'
-  s.add_dependency        'faraday_middleware', '~> 0.9'
+  s.add_dependency        'faraday',            '~> 1.0'
+  s.add_dependency        'faraday_middleware', '~> 1.0'
 
   s.description = <<-DESCRIPTION
 CMIS browser binding client library in ruby.


### PR DESCRIPTION
Reason: get rid of deprecation warnings when using Ruby 2.7.